### PR TITLE
fix: Fix client generation with composite types

### DIFF
--- a/lib/src/dmmf/dmmf.dart
+++ b/lib/src/dmmf/dmmf.dart
@@ -322,7 +322,7 @@ class Field {
   /// Is updated at, Auto update [DateTime] field.
   ///
   /// ⚠️ does not exist on 'type' but does on 'model'
-  final bool isUpdatedAt;
+  final bool? isUpdatedAt;
 
   /// Describes the data type in the same the way is is defined
   /// in the Prisma schema:

--- a/lib/src/dmmf/dmmf.g.dart
+++ b/lib/src/dmmf/dmmf.g.dart
@@ -143,7 +143,7 @@ Field _$FieldFromJson(Map<String, dynamic> json) => Field(
       isId: json['isId'] as bool,
       isReadOnly: json['isReadOnly'] as bool,
       isGenerated: json['isGenerated'] as bool?,
-      isUpdatedAt: json['isUpdatedAt'] as bool,
+      isUpdatedAt: json['isUpdatedAt'] as bool?,
       type: json['type'] as String,
       dbNames:
           (json['dbNames'] as List<dynamic>?)?.map((e) => e as String).toList(),


### PR DESCRIPTION
Client generation with schemas containing [composite types](https://www.prisma.io/docs/concepts/components/prisma-schema/data-model#defining-composite-types) was failing with this error:
```
dart run orm generate --debug

Unhandled exception:
type 'Null' is not a subtype of type 'bool' in type cast
#0      _$FieldFromJson (package:orm/src/dmmf/dmmf.g.dart:146:40)
#1      new Field.fromJson (package:orm/src/dmmf/dmmf.dart:385:7)
#2      _$ModelFromJson.<anonymous closure> (package:orm/src/dmmf/dmmf.g.dart:108:29)
#3      MappedListIterable.elementAt (dart:_internal/iterable.dart:413:31)
#4      ListIterator.moveNext (dart:_internal/iterable.dart:342:26)
#5      new _GrowableList._ofEfficientLengthIterable (dart:core-patch/growable_array.dart:189:27)
#6      new _GrowableList.of (dart:core-patch/growable_array.dart:150:28)
#7      new List.of (dart:core-patch/array_patch.dart:51:28)
#8      ListIterable.toList (dart:_internal/iterable.dart:213:44)
#9      _$ModelFromJson (package:orm/src/dmmf/dmmf.g.dart:109:12)
#10     new Model.fromJson (package:orm/src/dmmf/dmmf.dart:278:7)
#11     _$DatamodelFromJson.<anonymous closure> (package:orm/src/dmmf/dmmf.g.dart:94:29)
#12     MappedListIterable.elementAt (dart:_internal/iterable.dart:413:31)
#13     ListIterator.moveNext (dart:_internal/iterable.dart:342:26)
#14     new _GrowableList._ofEfficientLengthIterable (dart:core-patch/growable_array.dart:189:27)
#15     new _GrowableList.of (dart:core-patch/growable_array.dart:150:28)
#16     new List.of (dart:core-patch/array_patch.dart:51:28)
#17     ListIterable.toList (dart:_internal/iterable.dart:213:44)
#18     _$DatamodelFromJson (package:orm/src/dmmf/dmmf.g.dart:95:12)
#19     new Datamodel.fromJson (package:orm/src/dmmf/dmmf.dart:224:7)
#20     _$DocumentFromJson (package:orm/src/dmmf/dmmf.g.dart:10:28)
#21     new Document.fromJson (package:orm/src/dmmf/dmmf.dart:30:7)
#22     GenerateCommand.run (file:///C:/Users/andrs/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/orm-2.4.4/bin/src/commands/generate_command.dart:151:36)
<asynchronous suspension>
#23     CommandRunner.runCommand (package:args/command_runner.dart:209:13)
<asynchronous suspension>
#24     main (file:///C:/Users/andrs/AppData/Local/Pub/Cache/hosted/pub.dartlang.org/orm-2.4.4/bin/orm.dart:69:5)
<asynchronous suspension>
```

The problem was, that `isUpdatedAt` doesn't exist on `type` (as mentioned in the comment), but wasn't nullable.
After the change the client was generated successfuly and was working as intended.