### PR TITLE
fix(engine): Fix ignored errors

### DIFF
--- a/lib/universal_engine.dart
+++ b/lib/universal_engine.dart
@@ -224,9 +224,8 @@ class UniversalEngine implements Engine {
 
   /// Try throw an [PrismaException] from the [json].
   void _tryThrowPrismaException(Map<String, dynamic> json) {
-    if (json['meta']?['error'] != null && json['meta']['error'] is Map) {
-      final exception =
-          GraphQLError.fromJson(json['meta']['error']).toException(this);
+    if (json['error_code'] != null && json['error_code'] is String && json['error_code'].isNotEmpty) {
+      final exception = GraphQLError.fromJson(json).toException(this);
 
       logger.emit(Event.error, Payload(message: exception.message));
       throw exception;


### PR DESCRIPTION
So looks like all errors have an error_code key, the json['meta']['error'] was not working because it was a String instead of Map. validating by error_code is the right way I guess, at least is working in my use case. https://www.prisma.io/docs/reference/api-reference/error-reference#error-codes